### PR TITLE
adding categorical compatibility in xgboost trainer

### DIFF
--- a/retip/trainers/trainer.py
+++ b/retip/trainers/trainer.py
@@ -46,10 +46,19 @@ class Trainer:
         """
         """
 
+        def convert_columns_to_category(df):
+            columns_to_convert = ['Lipinski', 'GhoseFilter']
+            for col in columns_to_convert:
+                if col in df.columns:
+                    df[col] = df[col].astype('category')
+            return df
+
         if isinstance(data, Dataset):
             X = data.get_training_data()
+            X = convert_columns_to_category(X)
             return self._predict(self.filter_columns(X))
         elif isinstance(data, pd.DataFrame):
+            data = convert_columns_to_category(data)
             return self._predict(self.filter_columns(data))
         else:
             raise Exception(f'Unsupported data format {type(data)}')

--- a/retip/trainers/xgboost_trainer.py
+++ b/retip/trainers/xgboost_trainer.py
@@ -61,6 +61,10 @@ class XGBoostTrainer(Trainer):
     def do_train(self, verbosity: int = 1):
         if self.dataset is not None:
             training_data = self.dataset.get_training_data()
+            # Convert 'Lipinski' and 'GhoseFilter' to category type
+            for col in ['Lipinski', 'GhoseFilter']:
+                if col in training_data.columns:
+                    training_data[col] = training_data[col].astype('category')
             X_train = training_data.drop(self.dataset.target_column, axis=1)
             y_train = training_data[self.dataset.target_column].values
 
@@ -69,7 +73,7 @@ class XGBoostTrainer(Trainer):
             t = time.time()
 
             self.predictor = GridSearchCV(
-                xgb.XGBRegressor(n_jobs=self.n_cpu),
+                xgb.XGBRegressor(n_jobs=self.n_cpu, enable_categorical=True),
                 self.parameter_space,
                 cv=self.cv,
                 verbose=verbosity,


### PR DESCRIPTION
This PR addresses the errors encountered during xgboost training for the columns `['Lipinski', 'GhoseFilter']` as they're categorical.

Addresses this error while training:

`ValueError: DataFrame.dtypes for data must be int, float, bool or category. When categorical type is supplied, The experimental DMatrix parameter`enable_categorical` must be set to `True`.  Invalid columns:Lipinski: object, GhoseFilter: object`